### PR TITLE
Exceptions for Errors

### DIFF
--- a/inc/ShaderDebugger/Exceptions.h
+++ b/inc/ShaderDebugger/Exceptions.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <exception>
+#include <string>
+
+using namespace std;
+
+struct not_found_exception : public runtime_error {
+    explicit not_found_exception(const string &name) : runtime_error("Object \"" + name + "\" not found") {}
+};
+
+struct no_program_exception : public logic_error {
+    explicit no_program_exception() : logic_error("Program has not been read correctly") {}
+};
+
+struct invalid_shader_exception : public logic_error {
+    explicit invalid_shader_exception() : logic_error("Invalid Shader Program") {};
+};

--- a/inc/ShaderDebugger/Utils.h
+++ b/inc/ShaderDebugger/Utils.h
@@ -2,6 +2,7 @@
 
 #include <ShaderDebugger/Matrix.h>
 #include <glm/glm.hpp>
+#include <stdexcept>
 
 extern "C" {
 	#include <BlueVM.h>
@@ -17,6 +18,10 @@ namespace sd
 		if (var.type == bv_type_object) {
 			bv_object* obj = bv_variable_get_object(var);
 			bv_type type = obj->prop[0].type;
+
+            if (obj->type->props.name_count != c) {
+                throw std::runtime_error("Mismatch: Can't convert type " + std::string(obj->type->name) + " to type vec" + std::to_string(c));
+            }
 
 			if (type == bv_type_int)
 				for (u16 i = 0; i < obj->type->props.name_count; i++)


### PR DESCRIPTION
## Why Exceptions
Errors by return value is a long-used solution to error handling, but has issues in the fact it doesn't give much information, the return can easily be forgotten and errors can be confusing and hard to track down. Replacing with exceptions will reduce segfaults, making the library easier to work with for new users.
Read here for more details on why exceptions are useful: https://isocpp.org/wiki/faq/exceptions

## Changes
Adds the `Exception.h` file, containing three specific exception types:
 - `not_found_exception`
 - `no_program_exception`
 - `invalid_shader_exception`
`SetSource` now used exceptions instead of a boolean.
`AsVector` has check for vector size.
`Execute`, `AddGlobal`, `SetGlobalValue`, `Step`, `Immediate` and `SetArguments` have checks for the program existing.
`GetGlobalValue` and `SetGlobalValue` has a check for the global value and type existing respectively.
`SetArguments` throws exceptions instead of returning `nullptr`.

## Consequences
As the definition of `SetSource` has changed, any code using it will need to be replaced. In addition, applications using the library now need to use `try catch` blocks where errors may occur.

## Potential Changes
The pull request is open to extra commits.
While I did my best to cover everything, it may not cover all cases. In addition, you may want to modify it to have support for existing applications. Alternatively you could keep the old method, covering these cases in another way.

## Conclusion
The main reason for this pull request is to reduce unexpected errors in code (Fixing #3). This is largely aimed as a workflow improvement, as currently there is no documentation on the functions so debugging is otherwise difficult.